### PR TITLE
Enable package lock

### DIFF
--- a/interactive-closure-prototype/.npmrc
+++ b/interactive-closure-prototype/.npmrc
@@ -1,2 +1,2 @@
-package-lock=false
+package-lock=true
 audit=false

--- a/interactive_court_judgment/.npmrc
+++ b/interactive_court_judgment/.npmrc
@@ -1,2 +1,2 @@
-package-lock=false
+package-lock=true
 audit=false

--- a/interactive_prototype/.npmrc
+++ b/interactive_prototype/.npmrc
@@ -1,2 +1,2 @@
-package-lock=false
+package-lock=true
 audit=false


### PR DESCRIPTION
Enable package-lock so that the bot can update the package-lock too when it upgrades the npm version